### PR TITLE
commit: "fixing overlap for mobile width"

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -1139,7 +1139,7 @@ export function ReactorSwap() {
       transition={{ duration: 0.3, ease: "easeInOut" }}
     >
       <motion.div
-        className="grid grid-cols-2 gap-8 px-8 justify-between"
+        className="grid grid-cols-1 md:grid-cols-2 gap-8 px-8 justify-between"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1, duration: 0.2 }}
@@ -1177,8 +1177,9 @@ export function ReactorSwap() {
             </motion.div>
           </div>
         </motion.div>
+
         <motion.div
-          className="flex justify-end"
+          className="flex md:justify-end"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.2, duration: 0.2 }}


### PR DESCRIPTION
![gluon-reactor-swap-mobile](https://github.com/user-attachments/assets/7b943c7f-05a0-4866-8fd2-09d9eb94d0a2)
The GAU ad GAUC balances had an overlap in the UI, thus added the md: tailwind class for desktop, otherwise mobile first approach.