### PR TITLE
commit: "UI GAU and GAUC overlap bug in reactor in mobile fixed"

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -1139,7 +1139,7 @@ export function ReactorSwap() {
       transition={{ duration: 0.3, ease: "easeInOut" }}
     >
       <motion.div
-        className="grid grid-cols-1 md:grid-cols-2 gap-8 px-8 justify-between"
+        className="grid grid-cols-1 sm:grid-cols-2 gap-8 px-8 justify-between"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1, duration: 0.2 }}
@@ -1179,7 +1179,7 @@ export function ReactorSwap() {
         </motion.div>
 
         <motion.div
-          className="flex md:justify-end"
+          className="flex sm:justify-end"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.2, duration: 0.2 }}


### PR DESCRIPTION
![gluon-reactor-swap-mobile](https://github.com/user-attachments/assets/14516ac2-d60f-4169-8ff4-5015cf7d00d0)
The GAU and GAUC balances had an overlap in the UI, thus added the sm: tailwind class for desktop, otherwise mobile first approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved responsive layout for the GAU/GAUC balance section: stacks on small screens and displays side-by-side on larger screens.
  - Updated call-to-action alignment: left-aligned on very small screens, right-aligned from small breakpoints and up.
  - Visual-only adjustments with no changes to transaction behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->