### PR TITLE
fix: useless value shown during fusion removed

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -908,7 +908,7 @@ export function ReactorSwap() {
     }
 
     const isInputDisabled = !boxesReady || isCalculating || (isInitializing && !boxesReady);
-    // const showInput = isFromCard ? currentToken.symbol !== "GAU-GAUC" : true;
+    const showInput = isFromCard ? currentToken.symbol !== "GAU-GAUC" : true;
     const shouldRenderInputOrDisplay = !(currentToken.symbol === "GAU-GAUC" && !isFromCard);
 
     // Helper function to get token icon
@@ -1056,7 +1056,7 @@ export function ReactorSwap() {
             </SelectContent>
           </Select>
 
-          {shouldRenderInputOrDisplay ? (
+          {(showInput && shouldRenderInputOrDisplay) ? (
             <div className="flex pl-8 items-center justify-center sm:justify-end flex-1 min-w-0">
               <motion.div
                 key={`${currentToken.symbol}-input`}


### PR DESCRIPTION
<img width="1602" height="847" alt="fusion-useless-before" src="https://github.com/user-attachments/assets/dcdc84d1-0579-40e9-9480-6e3848fce5c9" />
<img width="1531" height="782" alt="fusion-useless-after" src="https://github.com/user-attachments/assets/7314bcfd-5200-4fc9-9b84-882742d9aa86" />
The useless value beside the GAU-GAUC toggle during Fusion is removed.