### PR TITLE
fix: "Issue #19 and #21"

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -66,8 +66,6 @@ const formatTokenAmount = (value: number | string): string => {
   }
 }
 
-
-
 // Helper function to check if two values are equal within precision tolerance
 /*const isPreciselyEqual = (value1: string, value2: string): boolean => {
   try {
@@ -1221,8 +1219,11 @@ export function ReactorSwap() {
 
   const currentAction = getActionType(fromToken.symbol, toToken.symbol)
 
+  const amount = parseFloat(fromAmount || "0");            // numeric amount user typed
+  const maxAmount = parseFloat(fromToken?.balance || "0"); // what's allowed
+
   const isSwapDisabled = () => {
-    if (isLoading || !isConnected || !boxesReady || isCalculating || (isInitializing && !boxesReady) || hasPendingTransactions) return true;
+    if (amount > maxAmount|| isLoading || !isConnected || !boxesReady || isCalculating || (isInitializing && !boxesReady) || hasPendingTransactions) return true;
 
     const fromVal = parseFloat(fromAmount);
     const toVal = parseFloat(toAmount);
@@ -1312,13 +1313,13 @@ export function ReactorSwap() {
                   </p>
                 )}
               </div>
-              <Button
+              {/* <Button
                 variant="ghost"
                 size="icon"
                 className="rounded-lg bg-white/5"
               >
                 <Settings2 className="h-5 w-5" />
-              </Button>
+              </Button> */}
             </div>
           </CardHeader>
 


### PR DESCRIPTION
The input accepts values greater than the max wallet balance, but the swap button still disables at amount >= maxAmount,
there is a reserve of 0.1 ERG always in the wallet, as according to previously written code.

and the swap setting button is removed for now.
<img width="856" height="828" alt="Screenshot 2025-09-07 195022" src="https://github.com/user-attachments/assets/09bc849b-9624-4406-999e-93614f84b3ad" />
<img width="841" height="826" alt="limit" src="https://github.com/user-attachments/assets/bb2ecfde-28af-4216-9abd-2456a534d7f0" />
<img width="833" height="813" alt="abovelimit" src="https://github.com/user-attachments/assets/4d1d668a-107f-4eff-a56b-2365ceec7cd1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dedicated GAU/GAUC card showing side-by-side balances and amounts.
  * MAX-to-fusion indicator for GAU/GAUC → ERG swaps.
  * Display of maximum ERG output alongside results.

* **Improvements**
  * More accurate MAX behavior and calculations for GAU/GAUC → ERG.
  * Higher ERG precision to reduce rounding issues.
  * Stricter input validation to block invalid/negative entries.
  * Smoother calculation triggers and improved swap feedback.

* **Style**
  * Settings button in the header is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->