### PR TITLE
Fix wallet restoration and transaction listener node URL

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -115,7 +115,7 @@ export function ReactorSwap() {
   const [oracleBox, setOracleBox] = useState<any>(null);
   const [isInitializing, setIsInitializing] = useState(true);
   const [initError, setInitError] = useState<string | null>(null);
-  const [nodeService] = useState(() => new NodeService(process.env.NEXT_PUBLIC_NODE || ""));
+  const [nodeService] = useState(() => new NodeService(process.env.NEXT_PUBLIC_NODE || "https://node.sigmaspace.io/"));
   const [balanceUpdateTrigger] = useState(0);
   const [boxesReady, setBoxesReady] = useState(false);
   const [receiptDetails, setReceiptDetails] = useState<ReceiptDetails>({


### PR DESCRIPTION
## Fix wallet restoration and transaction listener node URL

### Changes
- Fix wallet restoration with proper localStorage persistence and periodic checks
- Fix NodeService to use SDK's default node URL instead of empty string
- Ensures wallet connection and transaction monitoring work out-of-the-box
- Addresses issue where UI shows connected but transmutation fails

### Why Both Changes Are Required
- **Issue #51**: Wallet restoration works with localStorage persistence alone
- **Issue #50**: Transaction monitoring requires proper NodeService URL to avoid pending stuck state
- Both issues are independent but both need to be fixed for complete functionality

Fixes #50
Fixes #51

Fixed with assistance from cheetah agent using Cursor :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically restores previously connected wallets after page load.
  * Remembers the last connected wallet and clears it on disconnect.
  * Displays app state only after wallet initialization completes.

* **Bug Fixes**
  * Uses a stable default network endpoint when no custom configuration is provided.
  * Improves detection of existing wallet connections and cleans up when disconnected.
  * Reduces intermittent failures by periodically validating wallet availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->