### PR TITLE
feat: standardize input colors for editable/non-editable amounts

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -1083,7 +1083,7 @@ export function ReactorSwap() {
                   }}
                   className={cn(
                     "w-full min-w-[80px] border-0 bg-transparent text-left text-2xl font-bold focus:outline-none focus-visible:ring-0 sm:text-right sm:text-3xl",
-                    isFromCard ? "text-gray-400" : "text-gray-400",
+                    isFromCard ? "text-white placeholder:text-white" : "text-muted-foreground",
                     isInputDisabled && "cursor-not-allowed opacity-50"
                   )}
                   disabled={isInputDisabled}


### PR DESCRIPTION
Fix:#64

Editable inputs: white

Non-editable inputs: grey

This change ensures a consistent visual cue for users when interacting with editable vs non-editable fields across all operations
<img width="616" height="639" alt="Screenshot 2025-10-16 at 5 11 45 AM" src="https://github.com/user-attachments/assets/98a087b6-6f14-4fe1-a895-b190a455532b" />
<img width="616" height="639" alt="Screenshot 2025-10-16 at 5 11 54 AM" src="https://github.com/user-attachments/assets/b8dc3564-5cc1-4e8d-b8da-2e6f6c178e3b" />
<img width="616" height="639" alt="Screenshot 2025-10-16 at 5 12 02 AM" src="https://github.com/user-attachments/assets/e18226a8-bfb1-4bf4-9c67-6dafbe6ba682" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the FROM amount input styling in the swap interface to improve readability and visual consistency, especially in dark themes. When editing the FROM card, both text and placeholder now appear in high-contrast white; otherwise, a muted tone is used. This enhances clarity of entered values and placeholders without altering any functional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->