### PR TITLE
Add SVG logo to manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,6 +7,11 @@
   "theme_color": "#111827",
   "icons": [
     {
+      "src": "/logo/gluon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
+    {
       "src": "/logo/gluon.png",
       "sizes": "192x192",
       "type": "image/png"


### PR DESCRIPTION
This PR adds the newly provided gluon.svg logo into manifest to improve icon rendering quality across devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app manifest to include an SVG icon format in addition to the existing PNG icon for improved rendering across different platforms and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->