### PR TITLE
BUG fix: Reactor Swap button

### DIFF
--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -100,6 +100,9 @@ const formatErgAmount = (value: number | string | BigNumber): string => {
 };
 
 export function ReactorSwap() {
+  // Minimum ERG to keep in wallet for operations
+  const MIN_ERG_BUFFER = 0.1;
+
   const { isConnected, getBalance, getUtxos, ergoWallet } = useErgo();
   const [tokens, setTokens] = useState<Token[]>(defaultTokens);
   const [fromToken, setFromToken] = useState<Token>(tokens[0]);
@@ -132,7 +135,7 @@ export function ReactorSwap() {
   const [maxErgOutput, setMaxErgOutput] = useState<string>("0");
   const [maxErgOutputPrecise, setMaxErgOutputPrecise] = useState<string>("0"); // Precise value for calculations
   //const [isUpdatingProgrammatically, setIsUpdatingProgrammatically] = useState(false)
-  const updateBalancesRef = useRef(() => {});
+  const updateBalancesRef = useRef(() => { });
 
   // Transaction listener state
   const [transactionListener] = useState(() => createTransactionListener(nodeService));
@@ -429,9 +432,9 @@ export function ReactorSwap() {
               updatedTokens = updatedTokens.map((t) =>
                 t.symbol === "GAU"
                   ? {
-                      ...t,
-                      balance: formatMicroNumber(gauDecimalBalance).display,
-                    }
+                    ...t,
+                    balance: formatMicroNumber(gauDecimalBalance).display,
+                  }
                   : t
               );
             } else if (tokenBalance.tokenId === TOKEN_ADDRESS.gauc) {
@@ -440,9 +443,9 @@ export function ReactorSwap() {
               updatedTokens = updatedTokens.map((t) =>
                 t.symbol === "GAUC"
                   ? {
-                      ...t,
-                      balance: formatMicroNumber(gaucDecimalBalance).display,
-                    }
+                    ...t,
+                    balance: formatMicroNumber(gaucDecimalBalance).display,
+                  }
                   : t
               );
             }
@@ -633,20 +636,20 @@ export function ReactorSwap() {
         try {
           // Calculate actual fees for the current balance
           const balanceNanoErgs = ergsToNanoErgs(balanceNum);
-          
+
           // Get actual fees from the SDK
           const fees = await gluonInstance.getTotalFeeAmountFission(gluonBox, Number(balanceNanoErgs));
-          
+
           // Convert fees to ERG
           const actualTotalFee = parseFloat(nanoErgsToErgs(fees.totalFee).toString());
-          
-          // Small buffer for wallet operations (0.01 ERG)
-          const walletBuffer = 0.01;
-          
+
+          // Small buffer for wallet operations
+          const walletBuffer = MIN_ERG_BUFFER;
+
           // Calculate available ERG
           const availableErg = Math.max(0, balanceNum - actualTotalFee - walletBuffer);
           maxAmount = availableErg.toString();
-          
+
           console.log("🔍 MAX CALCULATION:", {
             balance: balanceNum,
             actualTotalFee,
@@ -658,7 +661,7 @@ export function ReactorSwap() {
           console.error("Error calculating max amount:", error);
           // Fallback to conservative estimate
           const estimatedTotalFeeERG = 0.011;
-          const walletBuffer = 0.01;
+          const walletBuffer = MIN_ERG_BUFFER;
           const availableErg = Math.max(0, balanceNum - estimatedTotalFeeERG - walletBuffer);
           maxAmount = availableErg.toString();
         }
@@ -1226,7 +1229,7 @@ export function ReactorSwap() {
       const ergBalance = parseFloat(ergBalanceStr);
       if (isNaN(ergInput) || ergInput <= 0) return true;
       if (ergInput > ergBalance) return true;
-      if (ergBalance - ergInput < 0.1) return true;
+      if (ergBalance - ergInput < MIN_ERG_BUFFER) return true;
 
       return false;
     }


### PR DESCRIPTION
## Description
Fixes #92 - Swap button now enables correctly when clicking MAX during fission

## Problem
The MAX button calculated the maximum fissionable ERG with a 0.01 ERG buffer, but the swap validation required 0.1 ERG to remain in the wallet, causing a validation mismatch.

## Solution
Standardized the minimum ERG buffer to 0.1 ERG by:
- Adding `MIN_ERG_BUFFER` constant (0.1 ERG)
- Updating MAX calculation to use the constant
- Updating swap validation to use the same constant

## Video proof

https://github.com/user-attachments/assets/08bba647-eb46-48e8-926b-c9972f4fdae1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Updated minimum ERG reserve requirement to 0.1 ERG, affecting wallet balance calculations and maximum swap amounts. This increases the amount of ERG required to be held in reserve during swap operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->