### PR TITLE
Remove npm/pnpm References from Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ This UI was built with Next.js, Tailwind CSS, Shadcn UI, Zustand, Framer Motion,
 
 Install bun, if you don't have it already, you can find it [here](https://bun.sh/docs/installation).
 
-If you don't want to use bun, you can always use NPM or PNPM.
-
 1. Install dependencies:
 
 ```bash
@@ -82,12 +80,6 @@ To install new shadcn components:
 
 ```bash
 bun x shadcn@latest add <component-name>
-```
-
-or with NPM / PNPM:
-
-```bash
-npx shadcn@latest add <component-name>
 ```
 
 While working with shadcn, all components are installed to src/lib/components/ui


### PR DESCRIPTION
# Remove npm/pnpm References from Documentation

## Problem

The README contains references to npm/pnpm as alternatives to bun, but the project is **specifically designed for bun**.

**Found Issues:**
- Line 65: "If you don't want to use bun, you can always use NPM or PNPM."
- Lines 87-91: npm/pnpm alternative for shadcn component installation

**Impact:**
- Creates confusion about package manager requirements
- Suggests npm/pnpm are viable alternatives when they're not
- Contradicts project's bun-specific design

## Solution

Removed all npm/pnpm references from README.md to clarify that bun is required.

### Changes Made

**File:** `README.md`

#### 1. Removed npm/pnpm Alternative Statement (Line 65)

**Before:**
```markdown
Install bun, if you don't have it already, you can find it [here](https://bun.sh/docs/installation).

If you don't want to use bun, you can always use NPM or PNPM.

1. Install dependencies:
```

**After:**
```markdown
Install bun, if you don't have it already, you can find it [here](https://bun.sh/docs/installation).

1. Install dependencies:
```

#### 2. Removed npm/pnpm Shadcn Alternative (Lines 87-91)

**Before:**
```markdown
To install new shadcn components:

```bash
bun x shadcn@latest add <component-name>
```

or with NPM / PNPM:

```bash
npx shadcn@latest add <component-name>
```
```

**After:**
```markdown
To install new shadcn components:

```bash
bun x shadcn@latest add <component-name>
```
```

### Key Features
- ✅ Removed all npm/pnpm references (8 lines)
- ✅ Preserved all bun instructions
- ✅ Clear bun-only requirement
- ✅ No confusing alternatives
- ✅ Documentation-only change (no code impact)

## Testing

### Verification

**✅ No npm/pnpm References**
```bash
grep -i "npm" README.md
grep -i "pnpm" README.md
# No results found in main README
```

**✅ Bun Instructions Intact**
- `bun install` - Present
- `bun dev` - Present
- `bun x shadcn@latest add` - Present

**✅ README Renders Correctly**
- All sections display properly
- Code blocks formatted correctly
- No broken markdown

## How to Test

```bash
# Checkout the branch
git checkout docs/remove-npm-pnpm-references

# Verify no npm/pnpm references
grep -i "npm" README.md
grep -i "pnpm" README.md
# Should return no results

# Verify bun instructions remain
grep "bun install" README.md
grep "bun dev" README.md
grep "bun x shadcn" README.md
# Should find all bun commands
```

## Files Changed

```
README.md
  - Removed npm/pnpm alternative statement (line 65)
  - Removed npm/pnpm shadcn alternative (lines 87-91)
  - Total: -8 lines
```

## Checklist

- [x] Code follows existing style and patterns
- [x] No unrelated files modified
- [x] All npm/pnpm references removed
- [x] All bun instructions preserved
- [x] Documentation is clear and unambiguous
- [x] No breaking changes
- [x] Conventional commit message used

## Related Issues

Fixes #109

---

**Ready for review!** 🚀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified installation instructions by consolidating to bun as the sole package manager. Removed alternative NPM and PNPM installation workflows from documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->