### PR TITLE
feat: Implement dynamic token rendering to replace hardcoded 'Neutron'/'Proton'

### DIFF
--- a/src/config/tokenConfig.ts
+++ b/src/config/tokenConfig.ts
@@ -48,25 +48,25 @@ export const tokenConfig: TokenConfig = {
     symbol: "ERG",
   },
   stableAsset: {
-    name: "Neutron",
-    symbol: "NEUTRON",
-    displayName: "Neutron",
-    description: "The stablecoin pegged to the base asset.",
+    name: "GAU",
+    symbol: "GAU",
+    displayName: "GAU",
+    description: "The stablecoin pegged to 1g of gold.",
   },
   volatileAsset: {
-    name: "Proton",
-    symbol: "PROTON",
-    displayName: "Proton",
+    name: "GAUC",
+    symbol: "GAUC",
+    displayName: "GAUC",
     description: "Tokenizes the reserve surplus and provides leveraged volatility and yield.",
   },
   peg: {
-    type: "Asset",
-    unit: "1 unit",
-    description: "Pegged to the base asset value.",
+    type: "Gold",
+    unit: "1g",
+    description: "Pegged to 1 gram of gold.",
   },
   pairToken: {
-    name: "Neutron-Proton Pair",
-    symbol: "NEUTRON-PROTON",
+    name: "GAU-GAUC Pair",
+    symbol: "GAU-GAUC",
   },
 };
 

--- a/src/lib/components/blockchain/swap/ReactorSwap.tsx
+++ b/src/lib/components/blockchain/swap/ReactorSwap.tsx
@@ -1209,9 +1209,9 @@ export function ReactorSwap() {
         transition={{ duration: 0.3, ease: "easeInOut" }}
       >
         <motion.div className="grid grid-cols-1 gap-3 px-4" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1, duration: 0.2 }}>
-          {/* GAU Box */}
+          {/* Stable Asset Box */}
           <div>
-            <span className="mb-1.5 block px-1 text-xs text-muted-foreground">GAU Balance: {formatTokenAmount(tokens.find((t) => t.symbol === stableSymbol)?.balance || "0")}</span>
+            <span className="mb-1.5 block px-1 text-xs text-muted-foreground">{stableSymbol} Balance: {formatTokenAmount(tokens.find((t) => t.symbol === stableSymbol)?.balance || "0")}</span>
             <motion.div
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
@@ -1237,9 +1237,9 @@ export function ReactorSwap() {
             </motion.div>
           </div>
 
-          {/* GAUC Box */}
+          {/* Volatile Asset Box */}
           <div>
-            <span className="mb-1.5 block px-1 text-xs text-muted-foreground">GAUC Balance: {formatTokenAmount(tokens.find((t) => t.symbol === volatileSymbol)?.balance || "0")}</span>
+            <span className="mb-1.5 block px-1 text-xs text-muted-foreground">{volatileSymbol} Balance: {formatTokenAmount(tokens.find((t) => t.symbol === volatileSymbol)?.balance || "0")}</span>
             <motion.div
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
@@ -1556,7 +1556,7 @@ export function ReactorSwap() {
                   >
                     {fromToken.symbol !== pairSymbol
                       ? `${formatTokenAmount(formatValue(receiptDetails.inputAmount))} ${fromToken.symbol}`
-                      : `${formatTokenAmount(gauAmount)} GAU - ${formatTokenAmount(gaucAmount)} GAUC`}
+                      : `${formatTokenAmount(gauAmount)} ${stableSymbol} - ${formatTokenAmount(gaucAmount)} ${volatileSymbol}`}
                   </motion.span>
                 </AnimatePresence>
               </motion.div>
@@ -1669,8 +1669,8 @@ export function ReactorSwap() {
                         exit={{ opacity: 0, scale: 0.8, y: -10 }}
                         transition={{ duration: 0.2 }}
                       >
-                        <div>{formatTokenAmount(formatValue(receiptDetails.outputAmount.gau))} GAU</div>
-                        <div>{formatTokenAmount(formatValue(receiptDetails.outputAmount.gauc))} GAUC</div>
+                        <div>{formatTokenAmount(formatValue(receiptDetails.outputAmount.gau))} {stableSymbol}</div>
+                        <div>{formatTokenAmount(formatValue(receiptDetails.outputAmount.gauc))} {volatileSymbol}</div>
                       </motion.div>
                     )}
                   </AnimatePresence>


### PR DESCRIPTION
### Addressed Issues:
Fixes the issue introduced in PR 107 where "GAU" and "GAUC" were incorrectly replaced with "Neutron" and "Proton" on the rendered frontend.

### Screenshots/Recordings:
n/a

### Additional Notes:
**Root Cause:**
PR 107 hardcoded the legacy strings as "Neutron" and "Proton" in the UI. For the Gluon Gold deployment, these need to remain "GAU" and "GAUC", while being dynamic under the hood.

**Resolution:**
- Restored the comprehensive generic token refactoring (from PR 96 logic).
- Updated `tokenConfig.ts` to set `GAU`, `GAUC`, and `GAU-GAUC` as the default symbols for the current Gluon Gold deployment.
- Replaced all hardcoded token text in the UI (e.g., `ReactorSwap.tsx`, `Dashboard.tsx`) with their respective dynamic config variables (e.g., `{tokenConfig.stableAsset.symbol}`).
- Verified locally that the UI now renders "GAU" and "GAUC" correctly while remaining fully configurable for future deployments like Gluon Dollar.

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [ ] If applicable, I have made corresponding changes or additions to the documentation.
- [ ] If applicable, I have made corresponding changes or additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the Stability Nexus's Discord server and I will share a link to this PR with the project maintainers there.
- [x] I have read the Contribution Guidelines.
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## AI Usage Disclosure
- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Token configuration rebranded from Neutron/PROTON to GAU/GAUC tokens pegged to gold.
  * Swap interface labels updated to dynamically display token symbols throughout the trading flow and balance displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->