### PR TITLE
fix: prevent button clipping on hover in Hero section

### DIFF
--- a/src/lib/components/blocks/home/Hero.tsx
+++ b/src/lib/components/blocks/home/Hero.tsx
@@ -7,7 +7,7 @@ import { tokenConfig, formatPegAsset } from "@/config/tokenConfig";
 export default function Hero() {
   const router = useRouter();
   return (
-    <motion.div className="relative overflow-hidden" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }}>
+    <motion.div className="relative" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }}>
       <div className="relative z-10">
         <div className="container pt-2">
           <div className="mx-auto max-w-4xl text-center">


### PR DESCRIPTION
Closes #139

Removes `overflow-hidden` from the Hero section's parent motion.div which was clipping the CTA buttons when they scale up (via framer-motion whileHover: scale 1.05).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Hero section's overflow display behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StabilityNexus/Gluon-Ergo-UI/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->