### PR TITLE
[codex] Fix hero button hover clipping

### DIFF
--- a/src/lib/components/blocks/home/Hero.tsx
+++ b/src/lib/components/blocks/home/Hero.tsx
@@ -27,7 +27,7 @@ export default function Hero() {
               </p>
             </motion.div>
 
-            <motion.div className="mt-8 flex justify-center gap-3" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.6, duration: 0.6 }}>
+            <motion.div className="mt-8 flex justify-center gap-3 pb-2" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.6, duration: 0.6 }}>
               <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                 <Button size={"lg"} onClick={() => router.push("/swap")}>
                   Start Trading


### PR DESCRIPTION
## Summary
- Add bottom spacing to the landing hero CTA row so scaled hover buttons have room inside the hero container.
- Keep the existing hero overflow behavior and shared Button component unchanged.

Fixes #139.

## Root Cause
The hero wrapper uses `overflow-hidden`, while the CTA buttons scale up on hover via Framer Motion. Without any bottom padding in the CTA row, the scaled buttons extend outside the hero's content box and get clipped at the bottom.

## Validation
- `npm run build` passes.
- `npx prettier --check src/lib/components/blocks/home/Hero.tsx` passes.
- `curl -I http://localhost:3000` returns `200 OK` with the local dev server running.

