### PR TITLE
fix: support bun.lock alongside bun.lockb in pages workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Detect package manager
         id: detect-package-manager
         run: |
-          if [ -f "${{ github.workspace }}/bun.lockb" ]; then
+          if [ -f "${{ github.workspace }}/bun.lock" ] || [ -f "${{ github.workspace }}/bun.lockb" ]; then
             echo "manager=bun" >> $GITHUB_OUTPUT
             echo "command=install" >> $GITHUB_OUTPUT
             echo "runner=bun" >> $GITHUB_OUTPUT
@@ -54,7 +54,7 @@ jobs:
             exit 1
           fi
       - name: Setup Bun (if needed)
-        if: hashFiles('**/bun.lockb') != ''
+        if: hashFiles('**/bun.lock', '**/bun.lockb') != ''
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
@@ -77,10 +77,10 @@ jobs:
           path: |
             .next/cache
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/bun.lockb') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/bun.lock', '**/bun.lockb') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/bun.lockb') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/bun.lock', '**/bun.lockb') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js


### PR DESCRIPTION
###  Addressed Issues:
Fixes GitHub Pages deployment failure caused by Bun lockfile detection mismatch in the CI workflow.

Fixes #(TODO:issue number)


###  Screenshots/Recordings:

TODO: If applicable, add screenshots or recordings that demonstrate the interface **before** and **after** the changes.


###  Additional Notes:
Newer versions of Bun (1.2+) generate a text-based bun.lock instead of the binary bun.lockb. The existing workflow only checked for bun.lockb, causing the package manager detection to fall back to npm, which then failed because package-lock.json was not present. This PR updates all 4 references in the workflow to check for both bun.lock and bun.lockb.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [.] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: perplexity


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [.] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [.] My code follows the project's code style and conventions
- [.] If applicable, I have made corresponding changes or additions to the documentation
- [.] If applicable, I have made corresponding changes or additions to tests
- [.] My changes generate no new warnings or errors
- [.] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [.] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [.] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [.] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bun lockfile detection to recognize additional lockfile variants
  * Modified caching configuration to include alternative lockfile formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->